### PR TITLE
Disable startup notifications for volume control commands

### DIFF
--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -23,11 +23,11 @@ volume_widget = wibox.widget {
 ]]
 volume_widget:connect_signal("button::press", function(_,_,_,button)
     if (button == 4) then
-        awful.spawn("amixer -D pulse sset Master 5%+")
+        awful.spawn("amixer -D pulse sset Master 5%+", false)
     elseif (button == 5) then
-        awful.spawn("amixer -D pulse sset Master 5%-")
+        awful.spawn("amixer -D pulse sset Master 5%-", false)
     elseif (button == 1) then
-        awful.spawn("amixer -D pulse sset Master toggle")
+        awful.spawn("amixer -D pulse sset Master toggle", false)
     end
 end)
 


### PR DESCRIPTION
Hello!
I used your volume widget and noticed, that when I change volume there is spinning cursor on desktop or window header (not inside window) for around 30 seconds. **htop** shows, that **Xorg-server** process used in that time up to ten percents. Lurked in your sources I realized that you have not disable or handle startup notifications for commands spawned with `awful.spawn` method. I had set second parameter `sn_rules` to `false` and everything goes well.
With best regards!