### PR TITLE
Add instant update to volume graphic upon changes caused by interactions

### DIFF
--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -1,8 +1,10 @@
 local awful = require("awful")
 local wibox = require("wibox")
 local watch = require("awful.widget.watch")
+local spawn = require("awful.spawn")
 
 local path_to_icons = "/usr/share/icons/Arc/status/symbolic/"
+local request_command = 'amixer -D pulse sget Master'
 
 volume_widget = wibox.widget {
     {
@@ -17,34 +19,33 @@ volume_widget = wibox.widget {
     end
 }
 
+local update_graphic = function(widget, stdout, stderr, reason, exit_code)
+    local mute = string.match(stdout, "%[(o%D%D?)%]")
+    local volume = string.match(stdout, "(%d?%d?%d)%%")
+    volume = tonumber(string.format("% 3d", volume))
+    local volume_icon_name
+    if mute == "off"                     then volume_icon_name="audio-volume-muted-symbolic"
+    elseif (volume >= 0 and volume < 25) then volume_icon_name="audio-volume-muted-symbolic"
+    elseif (volume < 50)                 then volume_icon_name="audio-volume-low-symbolic"
+    elseif (volume < 75)                 then volume_icon_name="audio-volume-medium-symbolic"
+    elseif (volume <= 100)               then volume_icon_name="audio-volume-high-symbolic"
+    end
+    widget.image = path_to_icons .. volume_icon_name .. ".svg"
+end
+
 --[[ allows control volume level by:
 - clicking on the widget to mute/unmute
 - scrolling when curson is over the widget
 ]]
 volume_widget:connect_signal("button::press", function(_,_,_,button)
-    if (button == 4) then
-        awful.spawn("amixer -D pulse sset Master 5%+", false)
-    elseif (button == 5) then
-        awful.spawn("amixer -D pulse sset Master 5%-", false)
-    elseif (button == 1) then
-        awful.spawn("amixer -D pulse sset Master toggle", false)
+    if (button == 4)     then awful.spawn("amixer -D pulse sset Master 5%+", false)
+    elseif (button == 5) then awful.spawn("amixer -D pulse sset Master 5%-", false)
+    elseif (button == 1) then awful.spawn("amixer -D pulse sset Master toggle", false)
     end
+    
+    spawn.easy_async(request_command, function(stdout, stderr, exitreason, exitcode)
+        update_graphic(volume_widget, stdout, stderr, exitreason, exitcode)
+    end)
 end)
 
-watch(
-    'amixer -D pulse sget Master', 1,
-    function(widget, stdout, stderr, reason, exit_code)   
-        local mute = string.match(stdout, "%[(o%D%D?)%]")
-        local volume = string.match(stdout, "(%d?%d?%d)%%")
-		volume = tonumber(string.format("% 3d", volume))
-		local volume_icon_name
-		if mute == "off" then volume_icon_name="audio-volume-muted-symbolic"
-		elseif (volume >= 0 and volume < 25) then volume_icon_name="audio-volume-muted-symbolic"
-		elseif (volume >= 25 and volume < 50) then volume_icon_name="audio-volume-low-symbolic"
-		elseif (volume >= 50 and volume < 75) then volume_icon_name="audio-volume-medium-symbolic"
-		elseif (volume >= 75 and volume <= 100) then volume_icon_name="audio-volume-high-symbolic"
-		end
-        widget.image = path_to_icons .. volume_icon_name .. ".svg"
-    end,
-    volume_widget
-)
+watch(request_command, 1, update_graphic, volume_widget)


### PR DESCRIPTION
Warning: Untested - I needed slightly different commands for my machine so I was unable to fully test this change. Please give it a whirl before accepting! (If this is inconvenient, I can try it out next time I'm at a different machine)

Added functionality to audio widget so the graphic updates immediately when you modify the volume through it, rather than taking up to a second to reflect changes.

Additionally made some minor changes to code to make it more consistent.